### PR TITLE
modifications to use a users sets instead of all public sets

### DIFF
--- a/collectionbuilder/index.html
+++ b/collectionbuilder/index.html
@@ -81,7 +81,8 @@
                             <% if (setDescription) { %><strong>Description: </strong><%- setDescription %><% } %>
                             <br />
                             <button type="button" class="btn btn-default edit" data-toggle="modal" data-target="#collection-edit" <% if (!owner) { %>disabled="disabled"<% } %>>Edit</button>
-                            <button type="button" class="btn btn-default edit permissions" data-toggle="modal" data-target="#collection-permissions-edit" <% if (!owner) { %>disabled="disabled"<% } %>>Permissions</button>
+                            <!-- <button type="button" class="btn btn-default edit permissions" data-toggle="modal" data-target="#collection-permissions-edit" <% if (!owner) { %>disabled="disabled"<% } %>>Permissions</button> -->
+                            <button type="button" class="btn btn-default edit permissions" data-toggle="modal" data-target="#collection-permissions-edit" style="display:none;"> Permissions</button>
                             <button type="button" class="btn btn-danger  delete" id="delete-collection" <% if (!owner) { %>disabled="disabled"<% } %>>Delete Collection</button>
                             <% } else { %>
                             Select a collection to view or edit

--- a/collectionbuilder/js/collectionbuilder.js
+++ b/collectionbuilder/js/collectionbuilder.js
@@ -175,7 +175,7 @@ $(function () {
                 setName: "",
                 systemId: "",
                 setDescription: "",
-                setSpec: "",
+                setSpec: null,
                 baseUrl: "",
                 thumbnailUrn: "",
                 collectionUrn: "",

--- a/collectionbuilder/js/collectionbuilder.js
+++ b/collectionbuilder/js/collectionbuilder.js
@@ -256,20 +256,25 @@ $(function () {
             return Backbone.sync.apply(this, arguments);
         },
 
+        // isEditor and isOwner both have been changed to only return true. This is due to the Get Collections for User endpoint in Librarycloud not
+        // attaching rights information to collections. However, since a user can now only get collections that they own, this should be ok.
+
         isEditor: function () {
-            return (this.attributes.accessRights && this.attributes.accessRights.role && this.attributes.accessRights.role.name == "editor")
-                || this.isOwner();
+            return true
+            // return (this.attributes.accessRights && this.attributes.accessRights.role && this.attributes.accessRights.role.name == "editor")
+                // || this.isOwner();
         },
 
         isOwner: function () {
-            return this.attributes.accessRights && this.attributes.accessRights.role && this.attributes.accessRights.role.name == "owner";
+            return true
+            // return this.attributes.accessRights && this.attributes.accessRights.role && this.attributes.accessRights.role.name == "owner";
 
         }
     });
 
     var LCCollectionList = Backbone.Collection.extend({
         model: LCCollection,
-        url: collectionsUrlBase + '/v2/collections?limit=999&sort=setName',
+        url: collectionsUrlBase + '/v2/collections/user',
 
         sync: function (command, model, options) {
             if (apiKey.get("key")) {
@@ -282,6 +287,9 @@ $(function () {
 
         initialize: function (options) {
             // this.on("all", function(e,c){console.log(e);console.log(arguments);});
+        },
+        comparator: function(set) {
+            return set.attributes.setName
         },
 
         addItem: function (setName) {
@@ -1433,7 +1441,7 @@ $(function () {
             $("#loading-collections-please-wait").modal('hide');
         },
         error: function(obj, response, opts) {
-            $("#loading-collections-please-wait .modal-body").html("<p>Unable to reach Collections API.</p><p>Reason: "+response.statusText+"</p><p>API Url: "+obj.url+"</p>");
+            $("#loading-collections-please-wait .modal-body").html("<p>Unable to reach Collections API. Please check that you have entered a valid API Key</p><p>Reason: "+response.statusText+"</p><p>API Url: "+obj.url+"</p><div class='form-group'><button type='button' class='btn btn-default ' data-dismiss='modal'>Ok</button></div>");
         }
     });
 
@@ -1445,7 +1453,7 @@ $(function () {
     var lcCollectionListView = new Backbone.CollectionView({
         el: $("ul#collection-list"),
         selectable: false,
-        collection: lcCollections,
+        collection: lcCollections.sort(),
         modelView: LCCollectionView,
     });
 


### PR DESCRIPTION
Librarycloud Utils now uses collections belonging to the user, instead of pulling all public collections. Some other modifications were needed due to this:

- isEditor and isOwner now both return true automatically. LibraryCloud's Get Collections For User method does not return role information, but guarantees that the user will only be seeing their own sets as handled by the API key sent in the request header.
- A comparator has been added to keep them correctly sorting by title
- A button has been added to close the error modal in case of an incorrect API key. Before this, the modal was not closeable, disallowing the user from using the UI to change their API key.