### PR TITLE
Remove hulmail address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /collectionbuilder/Web.config
 /Wendy's collection.txt
 /More Bicycles (2).txt
+.idea
+*.iml

--- a/collectionbuilder/index.html
+++ b/collectionbuilder/index.html
@@ -41,7 +41,7 @@
                         <span aria-hidden="true">&times;</span>
                     </a>
                     An API Key is required for adding, editing, or deleting collections. To get an API Key, contact
-                    <a href="mailto:librarycloud@hulmail.harvard.edu">librarycloud@hulmail.harvard.edu</a>.
+                    <a href="mailto:librarycloud@HU.onmicrosoft.com">librarycloud@HU.onmicrosoft.com</a>.
                     If you have an API key, enter it by clicking <a href="#" data-toggle="modal" data-target="#global-api-key">here</a>.
                 </div>
             </div>
@@ -430,7 +430,7 @@
                                 <input type="text" class="form-control" id="editAPIKey" value="<%- key %>" autofocus>
                                 <p class="help-block">
                                     An API Key is required for adding, editing, or deleting collections. The key will be saved on your device.
-                                    To get an API Key, contact <a href="mailto:librarycloud@hulmail.harvard.edu">librarycloud@hulmail.harvard.edu</a>.
+                                    To get an API Key, contact <a href="mailto:librarycloud@HU.onmicrosoft.com">librarycloud@HU.onmicrosoft.com</a>.
                                 </p>
                             </div>
                             <div class="form-group">


### PR DESCRIPTION
Remove hulmail address

JIRA Ticket: [LTSMAINT-305](https://jira.huit.harvard.edu/browse/LTSMAINT-305)

## What does this PR do?
This removes the hulmail address and replaces it with the new outlook group email address.

### Reviewers
@michael-lts 